### PR TITLE
Adventure and MiniMessage support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,14 @@
+# https://gist.github.com/qoomon/5dfcdf8eec66a051ecd85625518cfd13
+# feat: Commits, that adds a new feature
+# fix: Commits, that fixes a bug
+# refactor: Commits, that rewrite/restructure your code, however does not change any behaviour
+#  perf: Commits are special refactor commits, that improve performance
+# style: Commits, that do not affect the meaning (white-space, formatting, missing semi-colons, etc)
+# test: Commits, that add missing tests or correcting existing tests
+# docs: Commits, that affect documentation only
+# build: Commits, that affect build components like build tool, ci pipeline, dependencies, project version, ...
+# ops: Commits, that affect operational components like infrastructure, deployment, backup, recovery, ...
+# chore: Miscellaneous commits e.g. modifying .gitignore
 commit.types=feat, fix, refactor, perf, style, test, docs, build, ops, chore
 commit.scopes=
 # Allows you to validate commits only after this one, add the commmit hash here.

--- a/hope/build.gradle.kts
+++ b/hope/build.gradle.kts
@@ -14,9 +14,14 @@ dependencies {
     annotationProcessor(project(":processor"))
 
     implementation(project(":processor"))
-    implementation("org.json", "json", "20220924")
     implementation("org.tomlj", "tomlj", "1.1.0")
     implementation("org.slf4j", "slf4j-api", "2.0.7")
+    implementation("com.google.code.gson:gson:2.10.1")
+
+    // adventure
+    implementation("net.kyori", "adventure-api", "4.13.0")
+    implementation("net.kyori:adventure-text-serializer-gson:4.13.0")
+    implementation("net.kyori", "adventure-text-minimessage", "4.13.0")
 
     runtimeOnly("ch.qos.logback", "logback-classic", "1.4.6")
 

--- a/hope/config.toml
+++ b/hope/config.toml
@@ -1,1 +1,2 @@
 version = 2
+motd = "<red>A new hope minecraft server with minimessage <blue> <bold> support! Wuhu"

--- a/hope/src/main/java/io/github/madethoughts/hope/configuration/ServerConfig.java
+++ b/hope/src/main/java/io/github/madethoughts/hope/configuration/ServerConfig.java
@@ -20,20 +20,18 @@ package io.github.madethoughts.hope.configuration;
 
 import io.github.madethoughts.hope.configuration.processor.AbstractConfig;
 import io.github.madethoughts.hope.configuration.processor.Configuration;
-import org.tomlj.TomlTable;
+import io.github.madethoughts.hope.configuration.processor.Transformer;
+import net.kyori.adventure.text.Component;
+
+import static io.github.madethoughts.hope.configuration.processor.Transformers.MINI_MESSAGE;
 
 @Configuration(value = "config.toml", version = 2)
 public interface ServerConfig extends AbstractConfig {
 
-    static ServerConfig newConfig(TomlTable toml) {
-        var config = new ServerConfig$Implementation();
-        config.load(toml);
-        return config;
-    }
-
     int maxPlayers();
 
-    String motd();
+    @Transformer(MINI_MESSAGE)
+    Component motd();
 
     NetworkingConfig networking();
 }

--- a/hope/src/main/java/io/github/madethoughts/hope/json/deserializers/PlayerProfileDeserializer.java
+++ b/hope/src/main/java/io/github/madethoughts/hope/json/deserializers/PlayerProfileDeserializer.java
@@ -1,0 +1,57 @@
+/*
+ *     Hope - A minecraft server reimplementation
+ *     Copyright (C) 2023 Nick Hensel and contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.madethoughts.hope.json.deserializers;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import io.github.madethoughts.hope.profile.PlayerProfile;
+
+import java.lang.reflect.Type;
+import java.util.UUID;
+
+public class PlayerProfileDeserializer implements JsonDeserializer<PlayerProfile> {
+    /**
+     * Constructs an uuid from the mojang api's hex representation.
+     *
+     * @param hex the hex sent by mojang
+     * @return the UUID
+     */
+    private static UUID uuidFromHex(String hex) {
+        // adjust uuid format
+        var formattedUUID = hex.substring(0, 8) +
+                            '-' +
+                            hex.substring(8, 12) +
+                            '-' +
+                            hex.substring(12, 16) +
+                            '-' +
+                            hex.substring(16, 20) +
+                            '-' +
+                            hex.substring(20, 30);
+        return UUID.fromString(formattedUUID);
+    }
+
+    @Override
+    public PlayerProfile deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
+        var object = json.getAsJsonObject();
+        var uuid = uuidFromHex(object.get("id").getAsString());
+        var name = object.get("name").getAsString();
+        return new PlayerProfile(uuid, name);
+    }
+}

--- a/hope/src/main/java/io/github/madethoughts/hope/json/deserializers/package-info.java
+++ b/hope/src/main/java/io/github/madethoughts/hope/json/deserializers/package-info.java
@@ -16,33 +16,4 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package io.github.madethoughts.hope.configuration.processor;
-
-import org.tomlj.TomlTable;
-
-public interface AbstractConfig {
-    int version();
-
-    int defaultVersion();
-
-    void load(TomlTable tomlTable);
-
-    default CheckVersionResult checkVersion() {
-        try {
-            var version = version();
-            var defaultVersion = defaultVersion();
-
-            if (version > defaultVersion) return CheckVersionResult.INVALID;
-            if (defaultVersion > version) return CheckVersionResult.OUTDATED;
-            return CheckVersionResult.UP_TO_DATE;
-        } catch (IllegalStateException e) {
-            return CheckVersionResult.INVALID;
-        }
-    }
-
-    enum CheckVersionResult {
-        UP_TO_DATE,
-        OUTDATED,
-        INVALID
-    }
-}
+package io.github.madethoughts.hope.json.deserializers;

--- a/hope/src/main/java/io/github/madethoughts/hope/json/serializers/ComponentGsonTypeAdapter.java
+++ b/hope/src/main/java/io/github/madethoughts/hope/json/serializers/ComponentGsonTypeAdapter.java
@@ -16,33 +16,19 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package io.github.madethoughts.hope.configuration.processor;
+package io.github.madethoughts.hope.json.serializers;
 
-import org.tomlj.TomlTable;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import io.github.madethoughts.hope.Server;
+import net.kyori.adventure.text.Component;
 
-public interface AbstractConfig {
-    int version();
+import java.lang.reflect.Type;
 
-    int defaultVersion();
-
-    void load(TomlTable tomlTable);
-
-    default CheckVersionResult checkVersion() {
-        try {
-            var version = version();
-            var defaultVersion = defaultVersion();
-
-            if (version > defaultVersion) return CheckVersionResult.INVALID;
-            if (defaultVersion > version) return CheckVersionResult.OUTDATED;
-            return CheckVersionResult.UP_TO_DATE;
-        } catch (IllegalStateException e) {
-            return CheckVersionResult.INVALID;
-        }
-    }
-
-    enum CheckVersionResult {
-        UP_TO_DATE,
-        OUTDATED,
-        INVALID
+public class ComponentGsonTypeAdapter implements JsonSerializer<Component> {
+    @Override
+    public JsonElement serialize(Component src, Type typeOfSrc, JsonSerializationContext context) {
+        return Server.GSON_COMPONENT_SERIALIZER.serializeToTree(src);
     }
 }

--- a/hope/src/main/java/io/github/madethoughts/hope/json/serializers/StatusResponseSerializer.java
+++ b/hope/src/main/java/io/github/madethoughts/hope/json/serializers/StatusResponseSerializer.java
@@ -1,0 +1,67 @@
+/*
+ *     Hope - A minecraft server reimplementation
+ *     Copyright (C) 2023 Nick Hensel and contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.madethoughts.hope.json.serializers;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import io.github.madethoughts.hope.network.packets.clientbound.status.StatusResponse;
+
+import java.lang.reflect.Type;
+import java.util.Base64;
+
+public final class StatusResponseSerializer implements JsonSerializer<StatusResponse> {
+
+    @Override
+    public JsonElement serialize(StatusResponse src, Type typeOfSrc, JsonSerializationContext context) {
+        var faviconString = "data:image/png;base64," + Base64.getEncoder().encodeToString(src.favicon());
+
+        var json = new JsonObject();
+        json.add("version", context.serialize(src.version()));
+        json.add("players", context.serialize(src.players()));
+        json.add("description", context.serialize(src.chat()));
+        json.addProperty("favicon", faviconString);
+        json.addProperty("previewsChat", src.previewChat());
+        json.addProperty("enforcesSecureChat", src.enforcesSecureChat());
+        return json;
+    }
+
+    public static final class PlayersSerializer implements JsonSerializer<StatusResponse.Players> {
+
+        @Override
+        public JsonElement serialize(StatusResponse.Players src, Type typeOfSrc, JsonSerializationContext context) {
+            var json = new JsonObject();
+            json.addProperty("max", src.max());
+            json.addProperty("online", src.online());
+            return json;
+        }
+    }
+
+    public static final class VersionSerializer implements JsonSerializer<StatusResponse.Version> {
+
+        @Override
+        public JsonElement serialize(StatusResponse.Version src, Type typeOfSrc, JsonSerializationContext context) {
+            var json = new JsonObject();
+            json.addProperty("name", src.name());
+            json.addProperty("protocol", src.protocol());
+            return json;
+        }
+    }
+}

--- a/hope/src/main/java/io/github/madethoughts/hope/json/serializers/package-info.java
+++ b/hope/src/main/java/io/github/madethoughts/hope/json/serializers/package-info.java
@@ -16,33 +16,4 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package io.github.madethoughts.hope.configuration.processor;
-
-import org.tomlj.TomlTable;
-
-public interface AbstractConfig {
-    int version();
-
-    int defaultVersion();
-
-    void load(TomlTable tomlTable);
-
-    default CheckVersionResult checkVersion() {
-        try {
-            var version = version();
-            var defaultVersion = defaultVersion();
-
-            if (version > defaultVersion) return CheckVersionResult.INVALID;
-            if (defaultVersion > version) return CheckVersionResult.OUTDATED;
-            return CheckVersionResult.UP_TO_DATE;
-        } catch (IllegalStateException e) {
-            return CheckVersionResult.INVALID;
-        }
-    }
-
-    enum CheckVersionResult {
-        UP_TO_DATE,
-        OUTDATED,
-        INVALID
-    }
-}
+package io.github.madethoughts.hope.json.serializers;

--- a/hope/src/main/java/io/github/madethoughts/hope/network/PacketReceiver.java
+++ b/hope/src/main/java/io/github/madethoughts/hope/network/PacketReceiver.java
@@ -57,8 +57,8 @@ public final class PacketReceiver implements Runnable {
 
     public PacketReceiver(Connection connection, Thread senderThread, ServerConfig config) {
         this.connection = connection;
-        handshakeHandler = new HandshakeHandler(connection, config);
-        statusHandler = new StatusHandler(connection);
+        handshakeHandler = new HandshakeHandler(connection);
+        statusHandler = new StatusHandler(connection, config);
         loginHandler = new LoginHandler(connection);
         this.senderThread = senderThread;
     }

--- a/hope/src/main/java/io/github/madethoughts/hope/network/handler/HandshakeHandler.java
+++ b/hope/src/main/java/io/github/madethoughts/hope/network/handler/HandshakeHandler.java
@@ -18,12 +18,12 @@
 
 package io.github.madethoughts.hope.network.handler;
 
+import io.github.madethoughts.hope.Server;
 import io.github.madethoughts.hope.VersionedConstants;
-import io.github.madethoughts.hope.configuration.ServerConfig;
 import io.github.madethoughts.hope.network.Connection;
 import io.github.madethoughts.hope.network.NetworkingException;
+import io.github.madethoughts.hope.network.State;
 import io.github.madethoughts.hope.network.packets.clientbound.login.LoginDisconnect;
-import io.github.madethoughts.hope.network.packets.clientbound.status.StatusResponse;
 import io.github.madethoughts.hope.network.packets.serverbound.handshake.Handshake;
 
 /**
@@ -31,23 +31,19 @@ import io.github.madethoughts.hope.network.packets.serverbound.handshake.Handsha
  */
 public class HandshakeHandler implements PacketHandler<Handshake> {
     public static final String LOGIN_KICK_MESSAGE =
-            "Your version unsupported, only the version %s is supported. Please update your game!";
+            "<red> Your version unsupported, only the version %s is supported. Please update your game!"
+                    .formatted(VersionedConstants.VERSION);
     private final Connection connection;
-    private final ServerConfig serverConfig;
 
-    public HandshakeHandler(Connection connection, ServerConfig serverConfig) {
+    public HandshakeHandler(Connection connection) {
         this.connection = connection;
-        this.serverConfig = serverConfig;
     }
 
     @Override
     public void handle(Handshake packet) throws NetworkingException {
-        if (packet.protocolNumber() != VersionedConstants.PROTOCOL_VERSION) {
-            connection.queuePacket(switch (packet.nextState()) {
-                case STATUS -> new StatusResponse(serverConfig, -1); // player count doesn't matter here
-                case LOGIN -> new LoginDisconnect(LOGIN_KICK_MESSAGE.formatted(VersionedConstants.VERSION));
-                default -> throw new NetworkingException("Unexpected state after handshake");
-            });
+        // if the next state is status, we will just send the response
+        if (packet.protocolNumber() != VersionedConstants.PROTOCOL_VERSION && packet.nextState() == State.LOGIN) {
+            connection.queuePacket(new LoginDisconnect(Server.MINI_MESSAGE.deserialize(LOGIN_KICK_MESSAGE)));
         }
 
         connection.state(packet.nextState());

--- a/hope/src/main/java/io/github/madethoughts/hope/network/handler/LoginHandler.java
+++ b/hope/src/main/java/io/github/madethoughts/hope/network/handler/LoginHandler.java
@@ -18,6 +18,7 @@
 
 package io.github.madethoughts.hope.network.handler;
 
+import io.github.madethoughts.hope.Server;
 import io.github.madethoughts.hope.network.Connection;
 import io.github.madethoughts.hope.network.McCipher;
 import io.github.madethoughts.hope.network.NetworkingException;
@@ -109,7 +110,7 @@ public class LoginHandler implements PacketHandler<ServerboundPacket.LoginPacket
                     .build();
 
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            return PlayerProfile.fromJson(response.body());
+            return Server.GSON.fromJson(response.body(), PlayerProfile.class);
         } catch (NoSuchAlgorithmException | InterruptedException | IOException e) {
             throw new NetworkingException(e);
         }

--- a/hope/src/main/java/io/github/madethoughts/hope/network/handler/StatusHandler.java
+++ b/hope/src/main/java/io/github/madethoughts/hope/network/handler/StatusHandler.java
@@ -18,6 +18,8 @@
 
 package io.github.madethoughts.hope.network.handler;
 
+import io.github.madethoughts.hope.VersionedConstants;
+import io.github.madethoughts.hope.configuration.ServerConfig;
 import io.github.madethoughts.hope.network.Connection;
 import io.github.madethoughts.hope.network.NetworkingException;
 import io.github.madethoughts.hope.network.packets.clientbound.status.PingResponse;
@@ -31,23 +33,21 @@ import io.github.madethoughts.hope.network.packets.serverbound.status.StatusRequ
  */
 public class StatusHandler implements PacketHandler<ServerboundPacket.StatusPacket> {
     private final Connection connection;
+    private final ServerConfig serverConfig;
 
-    public StatusHandler(Connection connection) {this.connection = connection;}
+    public StatusHandler(Connection connection, ServerConfig serverConfig) {
+        this.connection = connection;
+        this.serverConfig = serverConfig;
+    }
 
     @Override
     public void handle(ServerboundPacket.StatusPacket packet) throws NetworkingException {
         connection.queuePacket(switch (packet) {
-            // TODO: 2/24/23 add real values and config here
+            // TODO: 3/26/23 favicon, previewChat, enforcesSecureChat, max players
             case StatusRequest() -> new StatusResponse(
-                    new StatusResponse.Version("1.19.3", 761),
-                    new StatusResponse.Players(
-                            10,
-                            0
-                    ),
-                    "test hahah",
-                    new byte[0],
-                    false,
-                    false
+                    new StatusResponse.Version(VersionedConstants.VERSION, VersionedConstants.PROTOCOL_VERSION),
+                    new StatusResponse.Players(serverConfig.maxPlayers(), -1), // values doesn't matter here
+                    serverConfig.motd(), new byte[0], false, false
             );
             case PingRequest(var payload) -> new PingResponse(payload);
         });

--- a/hope/src/main/java/io/github/madethoughts/hope/network/packets/clientbound/login/LoginDisconnect.java
+++ b/hope/src/main/java/io/github/madethoughts/hope/network/packets/clientbound/login/LoginDisconnect.java
@@ -18,18 +18,15 @@
 
 package io.github.madethoughts.hope.network.packets.clientbound.login;
 
+import io.github.madethoughts.hope.Server;
 import io.github.madethoughts.hope.network.ResizableByteBuffer;
 import io.github.madethoughts.hope.network.packets.clientbound.ClientboundPacket;
-import org.json.JSONObject;
+import net.kyori.adventure.text.Component;
 
-public record LoginDisconnect(String reason) implements ClientboundPacket {
+public record LoginDisconnect(Component reason) implements ClientboundPacket {
     @Override
     public void serialize(ResizableByteBuffer buffer) {
-        // TODO: 3/23/23 add chat support
-        buffer.writeString(
-                new JSONObject()
-                        .put("text", reason).toString()
-        );
+        buffer.writeString(Server.GSON.toJson(reason));
     }
 
     @Override

--- a/hope/src/main/java/io/github/madethoughts/hope/network/packets/clientbound/status/StatusResponse.java
+++ b/hope/src/main/java/io/github/madethoughts/hope/network/packets/clientbound/status/StatusResponse.java
@@ -18,59 +18,23 @@
 
 package io.github.madethoughts.hope.network.packets.clientbound.status;
 
-import io.github.madethoughts.hope.VersionedConstants;
-import io.github.madethoughts.hope.configuration.ServerConfig;
+import io.github.madethoughts.hope.Server;
 import io.github.madethoughts.hope.network.ResizableByteBuffer;
 import io.github.madethoughts.hope.network.packets.clientbound.ClientboundPacket;
-import org.json.JSONArray;
-import org.json.JSONObject;
-
-import java.util.Base64;
+import net.kyori.adventure.text.Component;
 
 public record StatusResponse(
         Version version,
         Players players,
-        // todo support chat object
-        String descriptionText,
+        Component chat,
         byte[] favicon,
         boolean previewChat,
         boolean enforcesSecureChat
 ) implements ClientboundPacket {
 
-    public StatusResponse(ServerConfig config, int onlinePlayers) {
-        // TODO: 3/23/23 previewChat and secureChat
-        this(
-                new Version(VersionedConstants.VERSION, VersionedConstants.PROTOCOL_VERSION),
-                new Players(config.maxPlayers(), onlinePlayers),
-                config.motd(), new byte[0],
-                true,
-                false
-        );
-    }
-
     @Override
     public void serialize(ResizableByteBuffer buffer) {
-        var faviconString = "data:image/png;base64," + Base64.getEncoder().encodeToString(favicon());
-
-        var json = new JSONObject()
-                .put("version", new JSONObject()
-                        .put("name", version.name())
-                        .put("protocol", version.protocol())
-                )
-                .put("players", new JSONObject()
-                        .put("max", players.max())
-                        .put("online", players.online())
-                        .put("sample", new JSONArray())
-                )
-                // TODO: 3/12/23 chat support
-                .put("description", new JSONObject()
-                        .put("text", descriptionText())
-                )
-                .put("favicon", faviconString)
-                .put("previewsChat", previewChat())
-                .put("enforcesSecureChat", enforcesSecureChat());
-
-        buffer.writeString(json.toString());
+        buffer.writeString(Server.GSON.toJson(this));
     }
 
     @Override

--- a/hope/src/main/java/io/github/madethoughts/hope/profile/PlayerProfile.java
+++ b/hope/src/main/java/io/github/madethoughts/hope/profile/PlayerProfile.java
@@ -18,8 +18,6 @@
 
 package io.github.madethoughts.hope.profile;
 
-import org.json.JSONObject;
-
 import java.util.UUID;
 
 /**
@@ -31,38 +29,4 @@ import java.util.UUID;
 public record PlayerProfile(
         UUID uuid,
         String name
-) {
-    /**
-     * Parses a new player profile from the json returned by the mojang api.
-     *
-     * @param json the json
-     * @return the player profile
-     */
-    public static PlayerProfile fromJson(String json) {
-        var jsonObject = new JSONObject(json);
-        var uuid = uuidFromHex(jsonObject.getString("id"));
-        var name = jsonObject.getString("name");
-
-        return new PlayerProfile(uuid, name);
-    }
-
-    /**
-     * Constructs an uuid from the mojang api's hex representation.
-     *
-     * @param hex the hex sent by mojang
-     * @return the UUID
-     */
-    private static UUID uuidFromHex(String hex) {
-        // adjust uuid format
-        var formattedUUID = hex.substring(0, 8) +
-                            '-' +
-                            hex.substring(8, 12) +
-                            '-' +
-                            hex.substring(12, 16) +
-                            '-' +
-                            hex.substring(16, 20) +
-                            '-' +
-                            hex.substring(20, 30);
-        return UUID.fromString(formattedUUID);
-    }
-}
+) {}

--- a/hope/src/main/java/module-info.java
+++ b/hope/src/main/java/module-info.java
@@ -1,9 +1,20 @@
 module io.github.madethoughts.hope {
     uses io.github.madethoughts.hope.configuration.NetworkingConfig;
+
     requires org.slf4j;
-    requires org.json;
     requires java.net.http;
     requires org.tomlj;
+    requires com.google.gson;
+
+    // adventure ----
+    requires net.kyori.adventure;
+    requires net.kyori.adventure.text.minimessage;
+    requires net.kyori.examination.string;
+    // adventure dependencies
+    requires net.kyori.adventure.text.serializer.gson;
+    requires java.sql;
 
     requires io.github.madethoughts.hope.processor;
+
+    exports io.github.madethoughts.hope.network.packets.clientbound.status to com.google.gson;
 }

--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -12,4 +12,7 @@ repositories {
 dependencies {
     implementation("org.tomlj", "tomlj", "1.1.0")
     implementation("com.squareup", "javapoet", "1.13.0")
+
+    implementation("net.kyori", "adventure-api", "4.13.0")
+    implementation("net.kyori", "adventure-text-minimessage", "4.13.0")
 }

--- a/processor/src/main/java/io/github/madethoughts/hope/configuration/processor/Transformer.java
+++ b/processor/src/main/java/io/github/madethoughts/hope/configuration/processor/Transformer.java
@@ -18,31 +18,8 @@
 
 package io.github.madethoughts.hope.configuration.processor;
 
-import org.tomlj.TomlTable;
+public @interface Transformer {
 
-public interface AbstractConfig {
-    int version();
+    Transformers value();
 
-    int defaultVersion();
-
-    void load(TomlTable tomlTable);
-
-    default CheckVersionResult checkVersion() {
-        try {
-            var version = version();
-            var defaultVersion = defaultVersion();
-
-            if (version > defaultVersion) return CheckVersionResult.INVALID;
-            if (defaultVersion > version) return CheckVersionResult.OUTDATED;
-            return CheckVersionResult.UP_TO_DATE;
-        } catch (IllegalStateException e) {
-            return CheckVersionResult.INVALID;
-        }
-    }
-
-    enum CheckVersionResult {
-        UP_TO_DATE,
-        OUTDATED,
-        INVALID
-    }
 }

--- a/processor/src/main/java/io/github/madethoughts/hope/configuration/processor/Transformers.java
+++ b/processor/src/main/java/io/github/madethoughts/hope/configuration/processor/Transformers.java
@@ -18,31 +18,6 @@
 
 package io.github.madethoughts.hope.configuration.processor;
 
-import org.tomlj.TomlTable;
-
-public interface AbstractConfig {
-    int version();
-
-    int defaultVersion();
-
-    void load(TomlTable tomlTable);
-
-    default CheckVersionResult checkVersion() {
-        try {
-            var version = version();
-            var defaultVersion = defaultVersion();
-
-            if (version > defaultVersion) return CheckVersionResult.INVALID;
-            if (defaultVersion > version) return CheckVersionResult.OUTDATED;
-            return CheckVersionResult.UP_TO_DATE;
-        } catch (IllegalStateException e) {
-            return CheckVersionResult.INVALID;
-        }
-    }
-
-    enum CheckVersionResult {
-        UP_TO_DATE,
-        OUTDATED,
-        INVALID
-    }
+public enum Transformers {
+    MINI_MESSAGE
 }

--- a/processor/src/main/java/module-info.java
+++ b/processor/src/main/java/module-info.java
@@ -2,6 +2,9 @@ module io.github.madethoughts.hope.processor {
     requires java.compiler;
     requires com.squareup.javapoet;
     requires org.tomlj;
+    requires net.kyori.adventure.text.minimessage;
+    requires net.kyori.adventure;
+    requires net.kyori.examination.api;
 
     exports io.github.madethoughts.hope.configuration.processor;
 }


### PR DESCRIPTION
This pr adds basic adventure and mini message support, providing serializier for gson (the minecraft chat object) and exchanges the org.json library with gson to be more flexible and able to use Adventure's gson-text-serializer.